### PR TITLE
Support exponents with decimal parts

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -760,11 +760,16 @@ impl<'a> Stream<'a> {
         if !self.at_end() {
             // current char must be a dot or an exponent sign
 
-            let c = self.curr_char_raw();
+            let mut c = self.curr_char_raw();
             if c == b'.' {
                 self.advance_raw(1); // skip dot
                 self.consume_digits();
-            } else if c == b'e' || c == b'E' {
+                if !self.at_end() {
+                    // Could have an exponent component.
+                    c = self.curr_char_raw();
+                }
+            }
+            if c == b'e' || c == b'E' {
                 check_exponent = true;
             } else {
                 // do nothing

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -36,6 +36,11 @@ test!(move_to_3, b"M 10 20 30 40 50 60",
     Segment { cmd: b'L', data: SegmentData::LineTo { x: 30.0, y: 40.0 } },
     Segment { cmd: b'L', data: SegmentData::LineTo { x: 50.0, y: 60.0 } }
 );
+test!(move_to_3_exponent, b"M 1e1 2.e1 30 40 50 60",
+    Segment { cmd: b'M', data: SegmentData::MoveTo { x: 10.0, y: 20.0 } },
+    Segment { cmd: b'L', data: SegmentData::LineTo { x: 30.0, y: 40.0 } },
+    Segment { cmd: b'L', data: SegmentData::LineTo { x: 50.0, y: 60.0 } }
+);
 
 test!(move_to_4, b"M 10 20 30 40 50 60 M 70 80 90 100 110 120",
     Segment { cmd: b'M', data: SegmentData::MoveTo { x: 10.0, y: 20.0 } },
@@ -72,6 +77,16 @@ test!(arc_to_10, b"M10-20A5.5.3-4 010-.1",
     Segment { cmd: b'M', data: SegmentData::MoveTo { x: 10.0, y: -20.0 } },
     Segment { cmd: b'A', data: SegmentData::EllipticalArc {
             rx: 5.5, ry: 0.3,
+            x_axis_rotation: -4.0,
+            large_arc: false, sweep: true,
+            x: 0.0, y: -0.1
+        }
+    }
+);
+test!(arc_to_10_exponent, b"M10-2e1A5.5 3.3e-1-4 010-.1",
+    Segment { cmd: b'M', data: SegmentData::MoveTo { x: 10.0, y: -20.0 } },
+    Segment { cmd: b'A', data: SegmentData::EllipticalArc {
+            rx: 5.5, ry: 0.33,
             x_axis_rotation: -4.0,
             large_arc: false, sweep: true,
             x: 0.0, y: -0.1

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -34,6 +34,7 @@ test_number!(number_15, b"1e2", 100.0);
 test_number!(number_16, b"1e+2", 100.0);
 test_number!(number_17, b"1E2", 100.0);
 test_number!(number_18, b"1e-2", 0.01);
+test_number!(number_18_exponent, b"1.3e-2", 0.013);
 test_number!(number_19, b"1ex", 1.0);
 test_number!(number_20, b"1em", 1.0);
 test_number!(number_21, b"12345678901234567890", 12345678901234567000.0);
@@ -85,6 +86,9 @@ test_length!(length_10, b"1%",  Length::new(1.0, LengthUnit::Percent));
 test_length!(length_11, b"1,",  Length::new(1.0, LengthUnit::None));
 test_length!(length_12, b"1 ,", Length::new(1.0, LengthUnit::None));
 test_length!(length_13, b"1 1", Length::new(1.0, LengthUnit::None));
+test_length!(length_14, b"1e0", Length::new(1.0, LengthUnit::None));
+test_length!(length_15, b"1.0e0", Length::new(1.0, LengthUnit::None));
+test_length!(length_16, b"1.0e0em", Length::new(1.0, LengthUnit::Em));
 
 #[test]
 fn length_err_1() {

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -25,6 +25,9 @@ macro_rules! test {
 test!(matrix_1, b"matrix(1 0 0 1 10 20)",
     TransformToken::Matrix { a: 1.0, b: 0.0, c: 0.0, d: 1.0, e: 10.0, f: 20.0 }
 );
+test!(matrix_1_exponent, b"matrix(1 0 0 1 1.3e1 2.44e-1)",
+    TransformToken::Matrix { a: 1.0, b: 0.0, c: 0.0, d: 1.0, e: 13.0, f: 0.244 }
+);
 
 test!(matrix_2, b"matrix(1, 0, 0, 1, 10, 20)",
     TransformToken::Matrix { a: 1.0, b: 0.0, c: 0.0, d: 1.0, e: 10.0, f: 20.0 }
@@ -36,6 +39,9 @@ test!(matrix_3, b" matrix ( 1, 0, 0, 1, 10, 20 )",
 
 test!(translate_1, b"translate(10 20)",
     TransformToken::Translate { tx: 10.0, ty: 20.0 }
+);
+test!(translate_1_exponent, b"translate(1.2e3 2.5e-2)",
+    TransformToken::Translate { tx: 1200.0, ty: 0.025 }
 );
 
 test!(translate_2, b"translate(10)",


### PR DESCRIPTION
Fixes RazrFalcon/libsvgparser#4

I have added new tests with the `_exponent` ending so that I don't create a large, but mostly useless diff.